### PR TITLE
add "category" tag to parser

### DIFF
--- a/feedparser.lua
+++ b/feedparser.lua
@@ -112,7 +112,10 @@ local function parse_entries(entries_el, format_str, base)
 				local author_url = (el:getChild('url') or blanky):getText()
 				if author_url and author_url ~= "" then entry.author_detail.href=resolve(author_url, rebase(el:getChild('url'), el_base)) end		
 			
-			elseif tag=='category' or tag=='dc:subject' then 
+			elseif tag=='category' then
+				entry.category = (el:getChild('term') or el):getText()
+			
+			elseif tag=='dc:subject' then
 				--todo
 			
 			elseif tag=='source' then


### PR DESCRIPTION
From https://tools.ietf.org/html/rfc4287#page-18, the Atom "category" tag has a "term" element with the text of the category.

As an example in the wild, the Environment Canada weather feeds make heavy use of the category: `<link rel="self" href="https://www.weather.gc.ca/rss/city/on-118_e.xml" type="application/atom+xml"/>`